### PR TITLE
n-queens cleanup

### DIFF
--- a/examples/coq/Queens.v
+++ b/examples/coq/Queens.v
@@ -14,6 +14,8 @@ Require Import Logic.Classical_Pred_Type.
 Require Import Logic.Classical_Prop.
 Require Import Permutation.
 Require Import Coq.Sorting.Mergesort.
+Require Import Psatz. (* for lia *)
+Require Import Space.Tactics.
 
 Module Import ZOrder := OTF_to_TTLB Z.
 Module Import ZSort := Sort ZOrder.
@@ -34,32 +36,24 @@ Context `{BAS:Basic}.
 Context `{SEA:@Search BAS}.
 Context `{INT:@Integer BAS}.
 
-Definition elem {A} `{eqDec A} (a:A) : list A -> bool :=
-  existsb (fun a' => if a =? a' then true else false).
-
-Fixpoint distinct {A} `{eqDec A} (l:list A) : bool :=
-  match l with
-  | a :: l => andb (negb (elem a l)) (distinct l)
-  | [] => true
-  end.
-
 Definition uncurry {A B C} (f:A->B->C) (ab:A*B) : C :=
   f (fst ab) (snd ab).
 
 Fixpoint nListSpace `{Basic} {A} (s:Space A) (n:nat) : Space (list A) :=
   match n with
   | 0%nat => single []
-  | S n => bind (nListSpace s n) (fun l => 
+  | S n => bind (nListSpace s n) (fun l =>
           bind s (fun a => single (a :: l)))
   end.
 
+Fixpoint index' {A} n (l : list A) :=
+  match l with
+  | [] => []
+  | a::l => (a,n) :: index' (plus one n) l
+  end.
+
 Definition index {A} : list A -> list (A * Int) :=
-  let fix rec n l :=
-    match l with
-    | [] => []
-    | a::l => (a,n) :: rec (plus one n) l
-    end 
-  in rec zero.
+  index' zero.
 
 Definition isLegal (queens : list (Int * Int)) : bool :=
   forallb (fun x => x) [
@@ -70,7 +64,7 @@ Definition isLegal (queens : list (Int * Int)) : bool :=
   ].
 
 Definition solveNQueens (n:nat) : Result (list (Int * Int)).
-  refine (search 
+  refine (search
     (bind (nListSpace (range zero (natToInt n)) n)
       (fun xs:list Int => _))).
   refine (let ps := index xs in _).
@@ -110,19 +104,7 @@ Lemma diagonalOptimization : forall (x1 x2 y1 y2 : Z),
     Zabs (x1 - x2) = Zabs (y1 - y2)
     <-> ((x1 + y1) = (x2 + y2) \/ (x1 - y1) = (x2 - y2)).
 Proof.
-  intros.
-  split; intros.
-  * apply Z.abs_eq_cases in H.
-    destruct H; omega.
-  * destruct H as [H | H].
-    + assert (x1 - x2 = y2 - y1) by omega.
-      assert (Z.abs (x1 - x2) = Z.abs (y2 - y1)) by (rewrite H0; reflexivity).
-      assert (-(y2 - y1) = y1 - y2) by omega.
-      assert (Z.abs (y2 - y1) = Z.abs (y1 - y2))
-        by (rewrite <- H2; symmetry; apply Z.abs_opp).      
-      rewrite H3 in H1. assumption.
-    + assert (x1 - x2 = y1 - y2) by omega.
-      rewrite H0. reflexivity.
+  intros. lia.
 Qed.
 
 Definition collision' (p1 p2 : Z * Z): Prop :=
@@ -135,12 +117,7 @@ Lemma collisionEquiv : forall (p1 p2 : Z * Z), collision p1 p2 <-> collision' p1
 Proof.
   intros. unfold collision. unfold collision'.
   destruct p1 as [x1 y1]. destruct p2 as [x2 y2].
-  split; intros.
-  * destruct H; intuition.
-    apply diagonalOptimization in H0.
-    destruct H0; intuition.
-  * destruct H; intuition;
-    do 2 (do 2 right; apply diagonalOptimization; intuition).
+  lia.
 Qed.
 
 Definition noCollisions' (positions : list (Z*Z)) : Prop :=
@@ -150,30 +127,23 @@ Definition noCollisions' (positions : list (Z*Z)) : Prop :=
 Lemma collisionsEquiv : forall (positions : list (Z*Z)),
     noCollisions positions <-> noCollisions' positions.
 Proof.
-  intros. unfold noCollisions. unfold noCollisions'.
-  split; intros.
-  * apply all_not_not_ex. intros. apply all_not_not_ex. intros.
-    intro Hn. firstorder.
-  * intro H'. apply H.
-    exists i. exists j. firstorder.
+  firstorder idtac.
 Qed.
 
 Definition existsCollision (positions : list (Z*Z)) : Prop :=
   exists (i j : nat), distinctIndices i j positions
                /\ collision (ith i positions) (ith j positions).
-  
+
 Lemma existsCollisionNot : forall (positions : list (Z*Z)),
     existsCollision positions <-> ~noCollisions positions.
 Proof.
   intros. unfold existsCollision. unfold noCollisions.
-  split; intros.
-  * intro H'. apply collisionsEquiv in H'. unfold noCollisions' in H'.
-    contradiction.
-  * apply not_all_ex_not in H. destruct H.
-    apply not_all_ex_not in H. destruct H.
-    apply imply_to_and in H. destruct H.
-    apply NNPP in H0.
-    exists x. exists x0. firstorder.
+  firstorder idtac.
+  apply not_all_ex_not in H. destruct H.
+  apply not_all_ex_not in H. destruct H.
+  apply imply_to_and in H. destruct H.
+  apply NNPP in H0.
+  firstorder idtac.
 Qed.
 
 Definition forSomePairAlike (positions : list (Z*Z))
@@ -185,60 +155,58 @@ Lemma xAlikeCollision : forall (positions : list (Z*Z)),
     forSomePairAlike positions (fun p => fst p)
     -> existsCollision positions.
 Proof.
-  unfold existsCollision. unfold forSomePairAlike. intros.
-  destruct H. destruct H.
-  exists x. exists x0. split; try intuition.
+  unfold existsCollision, forSomePairAlike.
+  intros.
+  destruct H as (i & j & D & E).
+  exists i, j.
   unfold collision.
-  remember (ith x positions) as p1.
-  remember (ith x0 positions) as p2.
-  destruct p1 as [x1 y1]. destruct p2 as [x2 y2].
-  simpl in H1. intuition.
+  repeat break_match.
+  intuition.
 Qed.
 
 Lemma yAlikeCollision : forall (positions : list (Z*Z)),
     forSomePairAlike positions (fun p => snd p)
     -> existsCollision positions.
 Proof.
-  unfold existsCollision. unfold forSomePairAlike. intros.
-  destruct H. destruct H.
-  exists x. exists x0. split; try intuition.
+  unfold existsCollision, forSomePairAlike.
+  intros.
+  destruct H as (i & j & D & E).
+  exists i, j.
   unfold collision.
-  remember (ith x positions) as p1.
-  remember (ith x0 positions) as p2.
-  destruct p1 as [x1 y1]. destruct p2 as [x2 y2].
-  simpl in H1. intuition.
+  repeat break_match.
+  intuition.
 Qed.
 
 Lemma sumAlikeCollision : forall (positions : list (Z*Z)),
     forSomePairAlike positions (fun p => fst p + snd p)
     -> existsCollision positions.
 Proof.
-  unfold existsCollision. unfold forSomePairAlike. intros.
-  do 2 (destruct H).
-  exists x. exists x0. split; try intuition.
+  unfold existsCollision, forSomePairAlike.
+  intros.
+  destruct H as (i & j & D & E).
+  exists i, j.
   unfold collision.
-  remember (ith x positions) as p1.
-  remember (ith x0 positions) as p2.
-  destruct p1 as [x1 y1]. destruct p2 as [x2 y2].
-  simpl in H1. right. right.
+  repeat break_match.
+  split; auto.
+  right. right.
   apply diagonalOptimization.
-  firstorder.
+  auto.
 Qed.
 
 Lemma diffAlikeCollision : forall (positions : list (Z*Z)),
     forSomePairAlike positions (fun p => fst p - snd p)
     -> existsCollision positions.
 Proof.
-  unfold existsCollision. unfold forSomePairAlike. intros.
-  do 2 (destruct H).
-  exists x. exists x0. split; try intuition.
+  unfold existsCollision, forSomePairAlike.
+  intros.
+  destruct H as (i & j & D & E).
+  exists i, j.
   unfold collision.
-  remember (ith x positions) as p1.
-  remember (ith x0 positions) as p2.
-  destruct p1 as [x1 y1]. destruct p2 as [x2 y2].
-  simpl in H1. right. right.
+  repeat break_match.
+  split; auto.
+  right. right.
   apply diagonalOptimization.
-  firstorder.
+  auto.
 Qed.
 
 Lemma alikeIfCollision : forall (positions : list (Z*Z)),
@@ -248,17 +216,14 @@ Lemma alikeIfCollision : forall (positions : list (Z*Z)),
     \/ forSomePairAlike positions (fun p => fst p + snd p)
     \/ forSomePairAlike positions (fun p => fst p - snd p).
 Proof.
-  unfold existsCollision. unfold forSomePairAlike.
-  intros. do 2 (destruct H). destruct H as [H H'].
-  unfold collision in H'.
-  remember (ith x positions) as p1.
-  remember (ith x0 positions) as p2.
-  destruct p1 as [x1 y1]. destruct p2 as [x2 y2].
-  destruct H'; [left | right; destruct H0;
-                       [left | right;
-                               apply diagonalOptimization in H0;
-                               destruct H0; [left | right]]];
-  (exists x; exists x0; rewrite <- Heqp1; rewrite <- Heqp2; intuition).
+  unfold existsCollision, forSomePairAlike, collision.
+  intros ? (i & j & D & C).
+  repeat break_match.
+  (intuition idtac); [left|
+                      right; left|
+                      right; right; apply diagonalOptimization in H0;
+                        destruct H0; [left | right]];
+  (exists i, j; rewrite Heqp; rewrite Heqp0; intuition).
 Qed.
 
 Theorem collisionIffAlike : forall (positions : list (Z*Z)),
@@ -269,73 +234,62 @@ Theorem collisionIffAlike : forall (positions : list (Z*Z)),
     \/ forSomePairAlike positions (fun p => fst p - snd p).
 Proof.
   intros. split; intros.
-  * apply alikeIfCollision; auto.
-  * destruct H; [| destruct H; [| destruct H]].
-    - apply xAlikeCollision. assumption.
-    - apply yAlikeCollision. assumption.
-    - apply sumAlikeCollision. assumption.
-    - apply diffAlikeCollision. assumption.
+  * auto using alikeIfCollision.
+  * destruct H as [|[|[|]]].
+    - auto using xAlikeCollision.
+    - auto using yAlikeCollision.
+    - auto using sumAlikeCollision.
+    - auto using diffAlikeCollision.
 Qed.
 
 Definition distinct' {A} (l : list A) : Prop :=
   forall (i j : nat) (d : A), distinctIndices i j l -> nth i l d <> nth j l d.
 
+Lemma distinct'_iff_NoDup : forall A (l : list A), distinct' l <-> NoDup l.
+Proof.
+  unfold distinct'.
+  destruct l.
+  - intuition. constructor. destruct H0. simpl in *. omega.
+  - split; intros.
+    + rewrite NoDup_nth with (d := a).
+      revert H. generalize (a :: l). clear l. intros.
+      destruct (eq_nat_dec i j); firstorder idtac.
+    + revert H H0. generalize (a :: l). clear l. intros.
+      rewrite NoDup_nth with (d := d) in H.
+      firstorder.
+Qed.
+
 Lemma distinctIndicesTransfer {A B} :
   forall (l1 : list A) (l2 : list B) (i j : nat),
     length l1 = length l2 ->
-    (distinctIndices i j l1 <-> distinctIndices i j l2).
-Proof. intros. unfold distinctIndices. split; intuition. Qed.
+    distinctIndices i j l1 -> distinctIndices i j l2.
+Proof. unfold distinctIndices. intuition. Qed.
 
 Lemma notAlikeIffDistinct :
   forall (positions : list (Z*Z)) (quantity : (Z*Z) -> Z),
     distinct' (map quantity positions)
     <-> ~forSomePairAlike positions quantity.
 Proof.
-  intros. unfold distinct'. unfold forSomePairAlike.
+  intros. unfold forSomePairAlike, distinct'.
   split; intros.
-  * intro H'. destruct H'. do 2 (destruct H0).
-    remember (nth x (map quantity positions) 0) as p1.
-    remember (nth x0 (map quantity positions) 0) as p2.
-    assert (length (map quantity positions) = length positions)
-      by apply map_length.
-    apply distinctIndicesTransfer with (i := x) (j := x0) in H2.
-    assert (distinctIndices x x0 (map quantity positions))
-      by intuition.
-    apply H with (d := 0) in H3.
-    apply H3.
-    unfold ith in H1.
-    assert (nth x (map quantity positions) 0
-            = nth x (map quantity positions) (quantity (0, 0)))
-           by (apply nth_indep; apply H2 in H0;
-               unfold distinctIndices in H0; intuition).
-    assert (nth x0 (map quantity positions) 0
-            = nth x0 (map quantity positions) (quantity (0, 0)))
-      by (apply nth_indep; apply H2 in H0;
-          unfold distinctIndices in H0; intuition).
-    rewrite H4. rewrite H5.
-    rewrite map_nth. rewrite map_nth.
-    assumption.
-  * apply not_ex_all_not with (n := i) in H.
-    apply not_ex_all_not with (n := j) in H.
-    apply not_and_or in H.
-    destruct H.
-    + assert (length (map quantity positions) = length positions)
-        by apply map_length.
-      apply distinctIndicesTransfer with (i0 := i) (j0 := j) in H1.
-      apply H1 in H0. contradiction.
-    + intro H'. apply H.
-      assert (nth i (map quantity positions) d
-              = nth i (map quantity positions) (quantity (0, 0)))
-        by (apply nth_indep; unfold distinctIndices in H0; intuition).
-      assert (nth j (map quantity positions) d
-              = nth j (map quantity positions) (quantity (0, 0)))
-        by (apply nth_indep; unfold distinctIndices in H0; intuition).
-      rewrite H1 in H'. rewrite H2 in H'. clear H1. clear H2.
-      unfold ith.
-      rewrite map_nth in H'. rewrite map_nth in H'. assumption.
+  * intro H'. destruct H' as (i & j & D & Q).
+    unfold ith in Q.
+    rewrite <- !map_nth with (f := quantity) in Q.
+    eapply H; eauto.
+    eapply distinctIndicesTransfer; [|eauto].
+    auto using map_length.
+  * intro H'.
+    apply H.
+    exists i, j.
+    split.
+    + eapply distinctIndicesTransfer; eauto using map_length.
+    + unfold ith.
+      rewrite <- !map_nth with (f := quantity).
+      rewrite !nth_indep with (d := quantity _) (d' := d) by firstorder.
+      assumption.
 Qed.
 
-Theorem noCollisionsIffDistinct : forall (positions : list (Z*Z)), 
+Theorem noCollisionsIffDistinct : forall (positions : list (Z*Z)),
     noCollisions positions
     <-> distinct' (map (fun p => fst p) positions)
       /\ distinct' (map (fun p => snd p) positions)
@@ -349,111 +303,30 @@ Proof.
        assert (existsCollision positions)
          by (apply collisionIffAlike; intuition);
        contradiction).
-  * destruct H as [Hx H1]. destruct H1 as [Hy H2]. destruct H2 as [Hs Hd].
+  * destruct H as (Hx & Hy & Hs & Hd).
     apply collisionsEquiv. unfold noCollisions'. intro H.
     apply notAlikeIffDistinct in Hx.
     apply notAlikeIffDistinct in Hy.
     apply notAlikeIffDistinct in Hs.
     apply notAlikeIffDistinct in Hd.
-    do 3 (destruct H).
-    unfold collision in H0. unfold forSomePairAlike in *.
-    remember (ith x positions) as p1.
-    remember (ith x0 positions) as p2.
+    destruct H as (i & j & D & Q).
+    unfold collision in Q. unfold forSomePairAlike in *.
+    remember (ith i positions) as p1.
+    remember (ith j positions) as p2.
     destruct p1 as [x1 y1]. destruct p2 as [x2 y2].
-    destruct H0; [apply Hx |
-      destruct H0; [apply Hy |
-        apply diagonalOptimization in H0;
-        destruct H0; [apply Hs | apply Hd]]];
-    (exists x; exists x0; rewrite <- Heqp1; rewrite <- Heqp2; split; intuition).
-Qed.
-
-Lemma existsb_false {A} : forall (l : list A) (f : A -> bool),
-    existsb f l = false <-> forall x, In x l -> f x = false.
-Proof.
-  intros. split; intros.
-  * induction l.
-    + inversion H0.
-    + simpl in H. apply orb_false_iff in H. destruct H.
-      simpl in H0. destruct H0; intuition.
-      rewrite <- H0. assumption.
-  * induction l.
-    + reflexivity.
-    + simpl. apply orb_false_iff. split.
-      - apply H. intuition.
-      - apply IHl. intros. simpl in H. apply H. intuition.
-Qed.
-
-Lemma In_nth_cons {A} : forall (a d : A) (l : list A) (i : nat),
-    (i < length l)%nat -> (nth i l d) <> a ->
-    In (nth (S i) (a :: l) d) (a :: l) -> In (nth i l d) l.
-Proof.
-  intros.
-  simpl in H1.
-  destruct H1.
-  * symmetry in H1. contradiction.
-  * assumption.
+    destruct Q; [apply Hx |
+      destruct H; [apply Hy |
+        apply diagonalOptimization in H;
+        destruct H; [apply Hs | apply Hd]]];
+    (exists i; exists j; rewrite <- Heqp1; rewrite <- Heqp2; split; intuition).
 Qed.
 
 Theorem distinctComputation {A} `{eqDec A} : forall (l : list A),
     distinct l = true <-> distinct' l.
 Proof.
-  intros. unfold distinct'. split.
-  * induction l; intros; unfold distinctIndices in H1.
-    + destruct H1. inversion H1.
-    + simpl in H0. apply andb_true_iff in H0. destruct H0.
-      destruct i; destruct j.
-      - simpl. destruct H1. destruct H3. exfalso. apply H4. reflexivity.
-      - simpl. apply negb_true_iff in H0. unfold elem in H0.
-        assert (forall x, In x l -> (if eqDecide a x then true else false) = false)
-          by (apply existsb_false; assumption).
-        destruct H1.
-        destruct H4.
-        assert ((j < length l)%nat) by intuition.
-        assert (In (nth j l d) l) by (apply nth_In; assumption).
-        apply H3 in H7.
-        destruct (eqDecide a (nth j l d)); try intuition.
-      - simpl. apply negb_true_iff in H0. unfold elem in H0.
-        assert (forall x, In x l -> (if eqDecide a x then true else false) = false)
-          by (apply existsb_false; assumption).
-        destruct H1.
-        destruct H4.
-        assert ((i < length l)%nat) by intuition.
-        assert (In (nth i l d) l) by (apply nth_In; assumption).
-        apply H3 in H7.
-        destruct (eqDecide a (nth i l d)); try intuition.
-      - destruct H1. destruct H3. simpl in *.
-        assert ((i < length l)%nat) by intuition.
-        assert ((j < length l)%nat) by intuition.
-        assert (i <> j) by intuition.
-        assert (distinctIndices i j l) by
-            (unfold distinctIndices; split; intuition).
-        apply IHl with (i := i) (j := j) (d := d) in H8; intuition.
-  * induction l; try reflexivity.
-    intros. simpl. apply andb_true_iff. split.
-    + apply negb_true_iff. unfold elem.
-      apply existsb_false.
-      intros.
-      destruct (eqDecide a x); try reflexivity.
-      assert (exists n, (n < length l)%nat /\ nth n l a = x)
-        by (apply In_nth; intuition).
-      do 2 (destruct H2).
-      assert (nth (S x0) (a :: l) a = x) by intuition.
-      assert (nth 0 (a :: l) a = a) by intuition.
-      assert (0%nat <> S x0) by intuition.
-      assert (S x0 < length (a :: l))%nat by (simpl; intuition).
-      assert (distinctIndices 0 (S x0) (a :: l))
-        by (unfold distinctIndices; split; intuition).
-      apply H0 with (d := a) in H8. simpl in H8.
-      rewrite H3 in H8.
-      contradiction.
-    + apply IHl. intros. unfold distinctIndices in H1.
-      destruct H1. destruct H2.
-      assert (S i < length (a :: l))%nat by (simpl; intuition).
-      assert (S j < length (a :: l))%nat by (simpl; intuition).
-      assert (S i <> S j) by intuition.
-      assert (distinctIndices (S i) (S j) (a :: l))
-        by (unfold distinctIndices; split; intuition).
-      apply H0 with (d := d) in H7. simpl in H7. assumption.
+  intros l.
+  rewrite distinct_iff_NoDup, distinct'_iff_NoDup.
+  intuition.
 Qed.
 
 Corollary distinctComputationFalse {A} `{eqDec A} : forall (l : list A),
@@ -479,7 +352,7 @@ Qed.
 Lemma intBijective : forall (i j : Int),
     ⟦ i ⟧ = ⟦ j ⟧ <-> i = j.
 Proof.
-  intros. split; intros.  
+  intros. split; intros.
   * apply denoteInjective. assumption.
   * rewrite H. reflexivity.
 Qed.
@@ -489,52 +362,18 @@ Lemma distinctBijective {A} {B} : forall (l : list A) (f : A -> B) (a : A),
     distinct' l <-> distinct' (map f l).
 Proof.
   intros.
+  rewrite !distinct'_iff_NoDup.
   split; intros.
-  * unfold distinct' in *.
-    intros.
-    assert (length (map f l) = length l) by apply map_length.
-    apply distinctIndicesTransfer with (i0 := i) (j0 := j) in H2.
-    assert (nth i l a <> nth j l a)
-      by (apply H0; apply H2; assumption).
-    assert (f (nth i l a) <> f (nth j l a))
-      by (intro H'; apply H in H'; contradiction).
-    assert (nth i (map f l) (f a) = nth i (map f l) d)
-      by (apply nth_indep; destruct H1; intuition).
-    assert (nth j (map f l) (f a) = nth j (map f l) d)
-      by (apply nth_indep; destruct H1; intuition).
-    rewrite <- H5. rewrite <- H6.
-    do 2 (rewrite map_nth).
-    assumption.
-  * unfold distinct' in *.
-    intros.
-    assert (length (map f l) = length l) by apply map_length.
-    apply distinctIndicesTransfer with (i0 := i) (j0 := j) in H2.
-    assert (nth i (map f l) (f d) <> nth j (map f l) (f d))
-      by (apply H0; apply H2; assumption).
-    do 2 (rewrite map_nth in H3).
-    intro H'.
-    apply H3.
-    apply H.
-    assumption.
+  * apply FinFun.Injective_map_NoDup; firstorder.
+  * eauto using NoDup_map_inv.
 Qed.
 
 Lemma distinctCons {A} : forall (a : A) (l : list A),
     distinct' (a :: l) -> distinct' l.
 Proof.
-  intros a l. revert a. induction l.
-  * unfold distinct'. intros.
-    unfold distinctIndices in H0. destruct H0. inversion H0.
-  * unfold distinct'. intros.
-    unfold distinctIndices in H0.
-    destruct H0. destruct H1.
-    assert (nth (S i) (a0 :: a :: l) d = nth i (a :: l) d)
-      by (simpl; reflexivity).
-    assert (nth (S j) (a0 :: a :: l) d = nth j (a :: l) d)
-      by (simpl; reflexivity).
-    rewrite <- H3. rewrite <- H4.
-    apply H.
-    unfold distinctIndices.
-    split; simpl; intuition.
+  intros a l.
+  rewrite !distinct'_iff_NoDup.
+  now inversion 1.
 Qed.
 
 Lemma distinctIntIffDistinctZ : forall (l : list Int),
@@ -550,42 +389,44 @@ Lemma fstIntFstZ : forall (l : list (Int * Int)),
     map fst (map denoteIntTuple l) = map (fun i => ⟦ i ⟧) (map fst l).
 Proof.
   intros.
-  induction l; simpl in *.
-  * reflexivity.
-  * destruct a. simpl. rewrite <- IHl. reflexivity.
+  rewrite !map_map.
+  apply map_ext.
+  destruct a.
+  reflexivity.
 Qed.
 
 Lemma sndIntSndZ : forall (l : list (Int * Int)),
     map snd (map denoteIntTuple l) = map (fun i => ⟦ i ⟧) (map snd l).
 Proof.
   intros.
-  induction l; simpl in *.
-  * reflexivity.
-  * destruct a. simpl. rewrite <- IHl. reflexivity.
+  rewrite !map_map.
+  apply map_ext.
+  destruct a.
+  reflexivity.
 Qed.
 
 Lemma sumIntSumZ : forall (l : list (Int * Int)),
     map (fun p => fst p + snd p) (map denoteIntTuple l)
     = map (fun i => ⟦ i ⟧) (map (uncurry plus) l).
 Proof.
-  intros.  
-  induction l; simpl in *.
-  * reflexivity.
-  * destruct a. unfold uncurry in *. simpl.
-    rewrite <- denotePlusOk. simpl.
-    rewrite <- IHl. reflexivity.
+  intros.
+  rewrite !map_map.
+  apply map_ext.
+  destruct a.
+  unfold uncurry.
+  space_crush.
 Qed.
 
 Lemma diffIntdiffZ : forall (l : list (Int * Int)),
     map (fun p => fst p - snd p) (map denoteIntTuple l)
     = map (fun i => ⟦ i ⟧) (map (uncurry minus) l).
 Proof.
-  intros.  
-  induction l; simpl in *.
-  * reflexivity.
-  * destruct a. unfold uncurry in *. simpl.
-    rewrite <- denoteMinusOk. simpl.
-    rewrite <- IHl. reflexivity.
+  intros.
+  rewrite !map_map.
+  apply map_ext.
+  destruct a.
+  unfold uncurry.
+  space_crush.
 Qed.
 
 Theorem isLegalIffNoCollisions : forall (positions : list (Int * Int)),
@@ -594,162 +435,59 @@ Theorem isLegalIffNoCollisions : forall (positions : list (Int * Int)),
 Proof.
   unfold isLegal.
   intros. split; intros.
-  * apply noCollisionsIffDistinct.
-    assert (forall x, In x
-                    [distinct (fst <$> positions);
-                     distinct (snd <$> positions);
-                     distinct (uncurry plus <$> positions);
-                     distinct (uncurry minus <$> positions)]
-                 -> x = true)
-      by (apply forallb_forall; assumption).
-    assert (distinct (fst <$> positions) = true)
-      by (apply H0; intuition).
-    assert (distinct (snd <$> positions) = true)
-      by (apply H0; intuition).
-    assert (distinct (uncurry plus <$> positions) = true)
-      by (apply H0; intuition).
-    assert (distinct (uncurry minus <$> positions) = true)
-      by (apply H0; intuition).
-    apply distinctComputation in H1.
-    apply distinctComputation in H2.
-    apply distinctComputation in H3.
-    apply distinctComputation in H4.
+  * rewrite forallb_forall in H.
+    rewrite noCollisionsIffDistinct.
     rewrite fstIntFstZ.
     rewrite sndIntSndZ.
     rewrite sumIntSumZ.
     rewrite diffIntdiffZ.
-    split; [| split; [| split]];
-      try (apply distinctIntIffDistinctZ; assumption).
+    rewrite <- !distinctIntIffDistinctZ.
+    rewrite <- !@distinctComputation.
+    intuition.
   * apply noCollisionsIffDistinct in H.
-    destruct H. destruct H0. destruct H1.
-    rewrite fstIntFstZ in H.
-    rewrite sndIntSndZ in H0.
-    rewrite sumIntSumZ in H1.
-    rewrite diffIntdiffZ in H2.
-    apply distinctIntIffDistinctZ in H.
-    apply distinctIntIffDistinctZ in H0.
-    apply distinctIntIffDistinctZ in H1.
-    apply distinctIntIffDistinctZ in H2.
-    apply distinctComputation in H.
-    apply distinctComputation in H0.
-    apply distinctComputation in H1.
-    apply distinctComputation in H2.
+    destruct H as (R & C & D1 & D2).
+    rewrite fstIntFstZ in *.
+    rewrite sndIntSndZ in *.
+    rewrite sumIntSumZ in *.
+    rewrite diffIntdiffZ in *.
+    rewrite <- distinctIntIffDistinctZ in *.
+    rewrite <- !@distinctComputation with (H := eqDecInteger) in *.
+    rewrite forallb_forall. intro x.
     simpl.
-    do 4 (rewrite andb_true_iff).
-    split; [| split; [| split; [| split]]]; intuition.
+    intuition congruence.
 Qed.
 
 Lemma nListSpaceLength {A} : forall (n : nat) (s : Space A) (l : list A),
    Ensembles.In ⟦ nListSpace s n ⟧ l -> length l = n.
 Proof.
   intro n.
-  induction n; intros.
-  * remember (nListSpace s 0) as l'.
-    simpl in Heql'.
-    rewrite Heql' in H.
-    rewrite denoteSingleOk in H.
-    inversion H.
-    reflexivity.
-  * remember (nListSpace s (S n)) as l'.
-    simpl in Heql'.
-    rewrite Heql' in H.
-    rewrite denoteBindOk in H.
-    rewrite bigUnionIsExists in H.
-    inversion H.
-    destruct H0.
-    rewrite denoteBindOk in H1.
-    rewrite bigUnionIsExists in H1.
-    destruct H1.
-    destruct H1.
-    apply IHn in H0.
-    rewrite denoteSingleOk in H2.
-    inversion H2.
-    simpl.
-    rewrite H0.
-    reflexivity.
+  induction n; simpl; intros; space_crush.
+  subst. simpl. eauto.
 Qed.
 
 Lemma denoteNatToInt : forall (n : nat),
     ⟦ natToInt n ⟧ = Z.of_nat n.
 Proof.
   intros.
-  induction n.
-  * simpl. apply denoteZeroOk.
-  * rewrite Nat2Z.inj_succ.
-    assert (Z.succ (Z.of_nat n) = 1 + Z.of_nat n) by omega.
-    rewrite H.
-    unfold natToInt. unfold natToInt in IHn.
-    rewrite denotePlusOk.
-    rewrite denoteOneOk.
-    rewrite IHn.
-    reflexivity.
-Qed.    
-    
+  induction n; cbn [natToInt]; space_crush.
+  lia.
+Qed.
+Hint Rewrite denoteNatToInt : space.
+
 Lemma rangeBounds : forall (n : nat) (i : Int),
     Ensembles.In ⟦ range zero (natToInt n) ⟧ i -> 0 <= ⟦ i ⟧ < Z.of_nat n.
 Proof.
   unfold range.
   intros.
-  rewrite denoteBindOk in H.
-  rewrite bigUnionIsExists in H.
-  inversion H.
-  destruct H0.
-  remember (le zero x && lt x (natToInt n)) as c.
-  symmetry in Heqc.
-  destruct c.
-  - rewrite denoteSingleOk in H1.
-    inversion H1.
-    apply andb_true_iff in Heqc.
-    destruct Heqc.
-    rewrite denoteLeOk in H3.
-    unfold lt in H4.
-    apply andb_true_iff in H4.
-    destruct H4.
-    apply negb_true_iff in H5.
-    rewrite denoteLeOk in H4.
-    rewrite <- H2.
-    rewrite denoteZeroOk in H3.
-    rewrite denoteEqualOk in H5.
-    assert (natToInt 0 = zero) by intuition.
-    rewrite Z.leb_le in H3.
-    rewrite Z.leb_le in H4.
-    rewrite Z.eqb_neq in H5.
-    rewrite denoteNatToInt in H4, H5.
-    split; try assumption.
-    apply Z_le_lt_eq_dec in H4.
-    destruct H4; intuition.
-  - rewrite denoteEmptyOk in H1.
-    inversion H1.
+  space_crush.
+  break_if; space_crush.
 Qed.
 
 Lemma nListSpaceListMember {A} : forall (n : nat) (s : Space A) (l : list A),
     Ensembles.In ⟦ nListSpace s n ⟧ l
     -> forall (a : A), In a l -> Ensembles.In ⟦ s ⟧ a.
 Proof.
-  intro n. induction n; intros.
-  * remember (nListSpace s 0) as l'.
-    simpl in Heql'.
-    rewrite Heql' in H.
-    rewrite denoteSingleOk in H.
-    simpl in H.
-    inversion H.
-    rewrite <- H1 in H0.
-    inversion H0.
-  * remember (nListSpace s (S n)) as l'.
-    simpl in Heql'.
-    rewrite Heql' in H.
-    rewrite denoteBindOk in H.
-    rewrite bigUnionIsExists in H.
-    inversion H.
-    destruct H1.
-    rewrite denoteBindOk in H2.
-    rewrite bigUnionIsExists in H2.
-    destruct H2. destruct H2.
-    rewrite denoteSingleOk in H3.
-    inversion H3. clear H3.
-    rewrite <- H4 in H0.
-    inversion H0; subst; intuition.
-    apply IHn with (l := x); intuition.
+  induction n; simpl; intros; space_crush; simpl in *; intuition idtac; eauto; congruence.
 Qed.
 
 Lemma nListSpaceRangeBounds : forall (n : nat) (l : list Int),
@@ -759,92 +497,58 @@ Proof.
   intros.
   apply nListSpaceListMember with (a := i) in H; [| assumption].
   apply rangeBounds. assumption.
-Qed.  
+Qed.
+
+Lemma indexLength' {A} : forall (l : list A) (i : Int),
+    length (index' i l) = length l.
+Proof.
+  induction l; simpl; auto.
+Qed.
 
 Lemma indexLength {A} : forall (l : list A), length (index l) = length l.
-  intros. unfold index.
-  assert (forall (l' : list A) (i : Int),
-             length ((fix rec (n : Int) (l0 : list A) {struct l0} : 
-                        list (A * Int) :=
-                        match l0 with
-                        | [] => []
-                        | a :: l1 => (a, n) :: rec (plus one n) l1
-                        end) i l') = length l').
-  * intro l'.
-    induction l'; intros; try reflexivity.
-    simpl. rewrite IHl'.
-    reflexivity.
-  * rewrite H. reflexivity.
-Qed.    
+  intros.
+  apply indexLength'.
+Qed.
+Hint Rewrite @indexLength : list.
 
-Lemma indexRecBounds {A} : forall (l' : list A) (i : Int) (p' : A * Int),
-    In p'
-       ((fix rec (n : Int) (l : list A) {struct l} : 
-           list (A * Int) :=
-           match l with
-           | [] => []
-           | a :: l0 => (a, n) :: rec (plus one n) l0
-           end) i l')
+Lemma indexBounds' {A} : forall (l' : list A) (i : Int) (p' : A * Int),
+    In p' (index' i l')
     -> ⟦ i ⟧ <= ⟦ (snd p') ⟧ < ⟦ i ⟧ + Z.of_nat (length l').
 Proof.
-  intro l'. induction l'; intros.
-  + inversion H.
-  + destruct H.
-  - replace (⟦ (snd p') ⟧) with (⟦ i ⟧); [| rewrite <- H; intuition].
-    simpl.
-    rewrite Zpos_P_of_succ_nat.
-    omega.
-  - apply IHl' in H.
-    rewrite denotePlusOk in H.
-    rewrite denoteOneOk in H.
-    assert (1 + Z.of_nat (length l') = Z.of_nat (length (a :: l')))
-      by (replace (Z.of_nat (length (a :: l')))
-          with (Z.succ (Z.of_nat (length l')));
-          try omega; simpl; rewrite Zpos_P_of_succ_nat; reflexivity).
-    rewrite <- H0.
-    omega.
-Qed.    
-     
+  induction l'; simpl; intros.
+  - intuition.
+  - destruct H.
+    + subst. simpl. lia.
+    + apply IHl' in H.
+      space_crush. lia.
+Qed.
+
 Lemma indexBounds {A} : forall (l : list A),
     let n := length l in
     forall (p : (A * Int)), In p (index l) -> 0 <= ⟦ snd p ⟧ < Z.of_nat n.
 Proof.
-  intros. unfold index in H.
-  apply (indexRecBounds l zero p) in H.
-  rewrite denoteZeroOk in H.
-  replace (Z.of_nat n) with (Z.of_nat (length l)); [| intuition].
-  omega.
+  unfold index.
+  intros.
+  apply (indexBounds' l zero p) in H.
+  space_crush.
 Qed.
 
-Lemma indexRecPreservesBound : forall (l : list Int) (n : nat),
+Lemma indexPreservesBound' : forall (l : list Int) (n : nat),
     (forall (i : Int), In i l -> 0 <= ⟦ i ⟧ < Z.of_nat n)
     -> (forall (p : (Int * Int)) (i : Int), In p
-       ((fix rec (n : Int) (l : list Int) {struct l} : 
-           list (Int * Int) :=
-           match l with
-           | [] => []
-           | a :: l0 => (a, n) :: rec (plus one n) l0
-           end) i l) -> 0 <= ⟦ (fst p) ⟧ < Z.of_nat n).
+       (index' i l) -> 0 <= ⟦ (fst p) ⟧ < Z.of_nat n).
 Proof.
-  intro l. induction l; intros.
-  * inversion H0.
-  * simpl in H0. destruct H0.
-    + assert (In a (a :: l)) by intuition.
-      apply H in H1.
-      rewrite <- H0.
-      simpl. simpl in H1.
-      assumption.
-    + apply IHl with (n := n) in H0; try assumption.
-      intros. assert (In i0 (a :: l)) by intuition.
-      apply H; assumption.
-Qed.      
-      
+  induction l; simpl; intros.
+  - intuition.
+  - destruct H0; subst; eauto.
+Qed.
+
 Lemma indexPreservesBound : forall (l : list Int) (n : nat),
     (forall (i : Int), In i l -> 0 <= ⟦ i ⟧ < Z.of_nat n)
     -> (forall (p : (Int * Int)), In p (index l) -> 0 <= ⟦ fst p ⟧ < Z.of_nat n).
 Proof.
-  intros. unfold index in H0.
-  apply indexRecPreservesBound with (n := n) in H0; assumption.
+  unfold index.
+  eauto using indexPreservesBound'.
 Qed.
 
 Lemma indexAllInBounds : forall (l : list Int),
@@ -852,20 +556,18 @@ Lemma indexAllInBounds : forall (l : list Int),
     (forall (i : Int), In i l -> 0 <= ⟦ i ⟧ < Z.of_nat n) ->
     allInBounds (map denoteIntTuple (index l)).
 Proof.
-  intros. unfold allInBounds. intros.
+  intros. unfold allInBounds, inBounds. intros.
   apply in_map_iff in H0.
   destruct H0.
-  unfold inBounds.
+  destruct p, x.
+
   rewrite map_length. rewrite indexLength.
   destruct H0.
   unfold denoteIntTuple in H0.
-  destruct p. destruct x.
-  assert (z = ⟦ fst (i, i0) ⟧) by (inversion H0; intuition).
-  assert (z0 = ⟦ snd (i, i0) ⟧) by (inversion H0; intuition).
-  rewrite H2, H3.
+  inversion H0. subst. clear H0.
   split.
-  * apply indexPreservesBound with (l := l); assumption.
-  * apply indexBounds; assumption.
+  * eapply indexPreservesBound with (p := (_, _)); eauto.
+  * eapply indexBounds with (p := (_, _)); eauto.
 Qed.
 
 Theorem solveNQueensSound : forall (n : nat) (l : list (Int * Int)),
@@ -875,193 +577,101 @@ Proof.
   unfold correct.
   unfold solveNQueens in H.
   apply searchSolution in H.
-  rewrite denoteBindOk in H.
-  rewrite bigUnionIsExists in H.
-  inversion H.
-  destruct H0.
-  remember (isLegal (index x)) as legal.
-  symmetry in Heqlegal.
-  destruct legal.
-  * rewrite denoteSingleOk in H1.
-    inversion H1.
-    apply isLegalIffNoCollisions in Heqlegal.
-    split; [| split].
-    - rewrite map_length. rewrite indexLength.
-      apply nListSpaceLength in H0. assumption.
-    - inversion H1.
-      apply indexAllInBounds.
-      apply nListSpaceRangeBounds.
-      assert (length x = n)
-        by (apply nListSpaceLength with (s := range zero (natToInt n));
-            assumption).
-      rewrite H4.
-      assumption.
-    - assumption.
-  * rewrite denoteEmptyOk in H1.
-    inversion H1.
+  space_crush.
+  break_if; space_crush.
+
+  assert (length x = n) by eauto using nListSpaceLength.
+  subst.
+
+  apply isLegalIffNoCollisions in Heqb.
+  eauto using indexAllInBounds, nListSpaceRangeBounds.
 Qed.
 
 Lemma distinctPermutation {A} : forall (l1 l2 : list A),
     Permutation l1 l2 -> distinct' l1 -> distinct' l2.
 Proof.
-  unfold distinct'. intros.
-  apply Permutation_nth with (d := d) in H.
-  destruct H.
-  destruct H2 as [f H2].
-  destruct H2.
-  destruct H3.
-  symmetry in H.
-  assert (distinctIndices i j l1)
-    by (apply distinctIndicesTransfer with (i0 := i) (j0 := j) in H;
-        intuition).  
-  unfold distinctIndices in H1, H5.
-  destruct H1.
-  destruct H6.
-  destruct H5.
-  destruct H8.
-  assert (nth i l2 d = nth (f i) l1 d) by (apply H4; assumption).
-  assert (nth j l2 d = nth (f j) l1 d) by (apply H4; assumption).
-  assert (distinctIndices (f i) (f j) l1) by (split; intuition).
-  apply H0 with (d := d) in H12.
-  rewrite H10. rewrite H11.
-  assumption.
+  intros l1 l2.
+  rewrite !distinct'_iff_NoDup.
+  apply Permutation_NoDup.
 Qed.
 
 Lemma permutationNoCollisions : forall (l1 l2 : list (Z*Z)),
     Permutation l1 l2 -> noCollisions l1 -> noCollisions l2.
 Proof.
-  intros.
-  apply noCollisionsIffDistinct in H0.
-  destruct H0. destruct H1. destruct H2.
-  assert (Permutation (map fst l1) (map fst l2))
-    by (apply Permutation_map; assumption).
-  assert (Permutation (map snd l1) (map snd l2))
-    by (apply Permutation_map; assumption).
-  assert (Permutation (map (fun p => fst p + snd p) l1)
-                      (map (fun p => fst p + snd p) l2))
-    by (apply Permutation_map; assumption).
-  assert (Permutation (map (fun p => fst p - snd p) l1)
-                      (map (fun p => fst p - snd p) l2))
-    by (apply Permutation_map; assumption).
-  apply noCollisionsIffDistinct.
-  split; [| split; [| split]].
-  * apply distinctPermutation with (map fst l1); intuition.
-  * apply distinctPermutation with (map snd l1); intuition.
-  * apply distinctPermutation with (map (fun p => fst p + snd p) l1); intuition.
-  * apply distinctPermutation with (map (fun p => fst p - snd p) l1); intuition.
-Qed.    
+  intros l1 l2 H.
+  rewrite !noCollisionsIffDistinct.
+  intuition eauto using distinctPermutation, Permutation_map.
+Qed.
 
 Lemma permutationIsLegal : forall (l1 l2 : list (Int * Int)),
     Permutation l1 l2 -> isLegal l1 = true -> isLegal l2 = true.
 Proof.
+  intros l1 l2 H.
+  rewrite !isLegalIffNoCollisions.
+  eauto using permutationNoCollisions, Permutation_map.
+Qed.
+
+Lemma permutationCorrect' : forall (l1 l2 : list (Z*Z)) (n : nat),
+    Permutation l1 l2 -> correct n l1 -> correct n l2.
+Proof.
+  unfold correct, allInBounds.
   intros.
-  apply isLegalIffNoCollisions.
-  apply isLegalIffNoCollisions in H0.
-  assert (Permutation (map denoteIntTuple l1) (map denoteIntTuple l2))
-    by (apply Permutation_map; intuition).
-  apply permutationNoCollisions with (map denoteIntTuple l1); intuition.
+  erewrite <- Permutation_length by eauto.
+  intuition idtac.
+  - eauto using Permutation_in, Permutation_sym.
+  - eauto using permutationNoCollisions.
 Qed.
 
 Lemma permutationCorrect : forall (l1 l2 : list (Int*Int)) (n : nat),
     Permutation l1 l2
     -> correct n (map denoteIntTuple l1) -> correct n (map denoteIntTuple l2).
 Proof.
-  unfold correct. unfold allInBounds.
-  intros.
-  destruct H0.
-  destruct H1.
-  assert (Permutation (map denoteIntTuple l1) (map denoteIntTuple l2))
-    by (apply Permutation_map; assumption).
-  assert (length (map denoteIntTuple l1) = length (map denoteIntTuple l2))
-    by (apply Permutation_length; assumption).
-  split; [| split].
-  * intuition.
-  * intros.
-    rewrite <- H4.
-    apply H1.
-    apply Permutation_in with (l := map denoteIntTuple l2); try assumption.
-    apply Permutation_sym. assumption.
-  * apply permutationNoCollisions with (l1 := map denoteIntTuple l1);
-      assumption.
-Qed.    
-
-Lemma permutationCorrect' : forall (l1 l2 : list (Z*Z)) (n : nat),
-    Permutation l1 l2 -> correct n l1 -> correct n l2.
-Proof.
-  unfold correct. unfold allInBounds.
-  intros.
-  destruct H0. destruct H1.
-  assert (length l1 = length l2) by (apply Permutation_length; assumption).
-  rewrite H3 in H0.
-  split; try assumption.
-  apply permutationNoCollisions with (l2 := l2) in H2; [| assumption].
-  split; try assumption.
-  rewrite <- H3.
-  intros.
-  apply Permutation_in with (l' := l1) in H4;
-    [| apply Permutation_sym; assumption].
-  apply H1; assumption.
+  eauto using permutationCorrect', Permutation_map.
 Qed.
 
-Definition zToInt := fromZ.
-
-Lemma zToIntOk : forall (z : Z), ⟦ zToInt z ⟧ = z.
-  apply denoteFromZOk.
-Qed.
+Local Notation zToInt := fromZ.
+Local Notation zToIntOk := denoteFromZOk.
 
 Lemma zToIntZeroOk : zToInt 0 = zero.
   apply denoteInjective.
-  rewrite denoteZeroOk.
-  apply zToIntOk.
+  space_crush.
 Qed.
 
 Lemma zToIntOneOk : zToInt 1 = one.
   apply denoteInjective.
-  rewrite denoteOneOk.
-  apply zToIntOk.
+  space_crush.
 Qed.
 
 Lemma zToIntPlusOk : forall (i j : Z), zToInt (i + j) = plus (zToInt i) (zToInt j).
   intros.
   apply denoteInjective.
-  rewrite denotePlusOk.
-  do 3 (rewrite zToIntOk).
-  reflexivity.
+  space_crush.
 Qed.
 
 Lemma zToIntEqualOk : forall (i j : Z),
     equal (zToInt i) (zToInt j) = Z.eqb i j.
 Proof.
-  intros.
-  rewrite denoteEqualOk.
-  do 2 (rewrite zToIntOk).
-  reflexivity.
+  space_crush.
 Qed.
 
 Lemma zToIntLeOk : forall (i j : Z),
     le (zToInt i) (zToInt j) = Z.leb i j.
 Proof.
-  intros.
-  rewrite denoteLeOk.
-  do 2 (rewrite zToIntOk).
-  reflexivity.
+  space_crush.
 Qed.
 
 Definition zTupleToIntTuple (p : Z*Z) : (Int*Int) :=
   let '(x, y) := p in (zToInt x, zToInt y).
 
+Lemma indexPreservesFst' {A} : forall (l : list A) i, map fst (index' i l) = l.
+Proof.
+  induction l; simpl; intros; congruence.
+Qed.
+
 Lemma indexPreservesFst {A} : forall (l : list A), (map fst (index l)) = l.
-  unfold index.
-  assert (forall l' i,
-             map fst 
-                 ((fix rec (n : Int) (l0 : list A) {struct l0} :=
-                    match l0 with
-                    | [] => []
-                    | a :: l1 => (a, n) :: rec (plus one n) l1
-                    end) i l') = l').
-  * intro l'. induction l'; intros; try intuition.
-    simpl. rewrite IHl'. reflexivity.
-  * intros. rewrite H. reflexivity.
+Proof.
+  intros.
+  apply indexPreservesFst'.
 Qed.
 
 Fixpoint countUp (n : nat) (start : Int) : list Int :=
@@ -1070,107 +680,87 @@ Fixpoint countUp (n : nat) (start : Int) : list Int :=
   | O => []
   end.
 
+Lemma sndIndexCountsUp' {A} : forall (l : list A) (i : Int),
+    map snd (index' i l) = countUp (length l) i.
+Proof.
+  induction l; simpl; intros; congruence.
+Qed.
+
 Lemma sndIndexCountsUp {A} : forall (l : list A) (n : nat),
     length l = n -> map snd (index l) = countUp n zero.
 Proof.
-  unfold index.
-  assert (forall (l' : list A) (n' : nat) (i : Int),
-             length l' = n' ->
-             map snd ((fix rec (n0 : Int) (l0 : list A) {struct l0} :=
-                         match l0 with
-                         | [] => []
-                         | a :: l1 => (a, n0) :: rec (plus one n0) l1
-                         end) i l') = countUp n' i).
-  * intro l'. induction l'; intros.
-    + simpl in H. subst. reflexivity.
-    + simpl. simpl in H. destruct n'; inversion H.
-      rewrite IHl' with (n' := n'); [| assumption].
-      rewrite H1. intuition.
-  * intros. rewrite H with (n' := n); [| assumption].
-    reflexivity.
+  intros.
+  subst.
+  apply sndIndexCountsUp'.
 Qed.
-      
-Lemma sndIndex {A} : forall (l : list (A*Int)) (n : nat),
-    length l = n -> map snd l = countUp n zero -> index (map fst l) = l.
+
+Lemma sndIndex' {A} :
+  forall (l : list (A * Int)) i,
+      map snd l = countUp (length l) i ->
+      index' i (map fst l) = l.
+Proof.
+  induction l; simpl; intros.
+  - auto.
+  - destruct a; simpl in *.
+    f_equal.
+    + congruence.
+    + apply IHl. congruence.
+Qed.
+
+Lemma sndIndex {A} : forall (l : list (A*Int)),
+    map snd l = countUp (length l) zero -> index (map fst l) = l.
 Proof.
   unfold index.
-  assert (forall (l' : list (A * Int)) (n' : nat) (i : Int),
-             length l' = n' ->
-             map snd l' = countUp n' i ->
-             (fix rec (n0 : Int) (l0 : list A) {struct l0} :=
-                match l0 with
-                | [] => []
-                | a :: l1 => (a, n0) :: rec (plus one n0) l1
-                end) i (map fst l') = l').
-  * intro l'. induction l'; intros; try reflexivity.
-    destruct n'; inversion H.
-    simpl in H0. inversion H0.
-    simpl. rewrite IHl' with (n' := n'); try assumption.
-    destruct a; reflexivity.
-  * intros. rewrite H with (n' := n); intuition.
-Qed.    
+  eauto using sndIndex'.
+Qed.
 
 Lemma intToZInvolutive : forall (p : Z*Z),
     denoteIntTuple (zTupleToIntTuple p) = p.
 Proof.
   intros. destruct p. simpl.
-  do 2 (rewrite zToIntOk).
-  reflexivity.
+  auto using f_equal2, zToIntOk.
 Qed.
 
 Lemma intToZInvolutiveMap : forall (l : list (Z*Z)),
     map denoteIntTuple (map zTupleToIntTuple l) = l.
 Proof.
   intros.
-  induction l.
-  * reflexivity.
-  * simpl. rewrite intToZInvolutive.
-    simpl in IHl. rewrite IHl.
-    reflexivity.
+  rewrite map_map.
+  rewrite map_ext with (g := id).
+  - apply map_id.
+  - apply intToZInvolutive.
 Qed.
 
 Lemma intSndToZSnd : forall (l : list (Z*Z)),
     map snd (map zTupleToIntTuple l) = map zToInt (map snd l).
 Proof.
   intros.
-  induction l; try reflexivity.
-  simpl. simpl in IHl. rewrite IHl.
-  destruct a. simpl. reflexivity.
+  rewrite !map_map.
+  apply map_ext.
+  destruct a; reflexivity.
 Qed.
 
 Lemma zToIntInj : forall (z1 z2 : Z),
     zToInt z1 = zToInt z2 -> z1 = z2.
 Proof.
   intros.
-  rewrite <- (zToIntOk z1).
-  rewrite <- (zToIntOk z2).
-  rewrite H. reflexivity.
+  apply f_equal with (f := denote) in H.
+  space_crush.
 Qed.
 
 Lemma zToIntMapInj : forall (l1 l2 : list Z),
     map zToInt l1 = map zToInt l2 -> l1 = l2.
 Proof.
-  intro l1. induction l1; intros.
-  * simpl in H. destruct l2; try inversion H. reflexivity.
-  * simpl in H. destruct l2; try inversion H.
-    apply IHl1 in H2. apply zToIntInj in H1. subst.
-    reflexivity.
+  eauto using map_inj, zToIntInj.
 Qed.
 
 Lemma zToIntMapBij : forall (l1 l2 : list Z),
     map zToInt l1 = map zToInt l2 <-> l1 = l2.
 Proof.
   intros. split; intros.
-  * apply zToIntMapInj; assumption.
-  * rewrite H. reflexivity.
+  * auto using zToIntMapInj.
+  * congruence.
 Qed.
-
-Lemma zToIntInv : forall (i : Int), zToInt ⟦ i ⟧ = i.
-  intros.
-  apply denoteInjective.
-  rewrite zToIntOk.
-  reflexivity.
-Qed.  
 
 Fixpoint zCountUp (n : nat) (start : Z) : list Z :=
   match n with
@@ -1183,11 +773,9 @@ Lemma countUpToZCountUp : forall (n : nat) (start : Int),
 Proof.
   intro n. induction n; intros.
   * reflexivity.
-  * unfold countUp. rewrite IHn. unfold zCountUp.
-    rewrite denotePlusOk.
-    rewrite denoteOneOk. simpl.
-    rewrite zToIntInv.
-    reflexivity.
+  * cbn [countUp zCountUp map].
+    rewrite IHn.
+    space_crush.
 Qed.
 
 Lemma sortedBySecond : forall (l : list (Z*Z)),
@@ -1197,93 +785,71 @@ Proof.
   intros; induction H; simpl; constructor; try assumption.
 Qed.
 
-Lemma ZofSucc : forall (n : nat), Z.of_nat (S n) = 1 + Z.of_nat n.
-  intros. induction n.
-  * simpl. reflexivity.
-  * unfold Z.of_nat. do 2 (rewrite Zpos_P_of_succ_nat).
-    rewrite IHn. omega.
-Qed.
-
-Lemma sortedListAllGreater : forall (l : list Z) (a : Z),
-    Sorted.Sorted (fun z1 z2 => is_true (leb z1 z2)) l
-    -> Sorted.HdRel (fun z1 z2 : Z => is_true (leb z1 z2)) a l
-    -> (forall z, In z l -> a <= z).
-Proof.
-  intros l a H. revert a. induction H; intros.
-  * inversion H0.
-  * assert (forall z, In z l -> a <= z) by (apply IHSorted; assumption).
-    apply Sorted.HdRel_inv in H1.
-    apply leb_le in H1.
-    apply Z.compare_ngt_iff in H1.
-    assert (a0 <= a) by omega.
-    destruct H2; try omega.
-    apply H3 in H2. omega.
-Qed.    
-    
 Theorem sortDistinctListRangeGeneral : forall (l : list Z) (n : nat) (i : Z),
-    Sorted.LocallySorted (fun z1 z2 => is_true (leb z1 z2)) l
+    Sorted.StronglySorted Z.le l
     -> length l = n
-    -> distinct' l -> (forall z, In z l -> i <= z < i + Z.of_nat n)
+    -> NoDup l
+    -> (forall z, In z l -> i <= z < i + Z.of_nat n)
     -> l = zCountUp n i.
 Proof.
   intros l n i H. revert n i.
-  induction H; intros.
-  * simpl in H. rewrite <- H. reflexivity.
-  * simpl in H. rewrite <- H. simpl.
-    rewrite <- H in H1. simpl in H1.
-    assert (i <= a < i + 1) by (apply H1; intuition).
-    assert (a = i) by omega.
-    rewrite H3. reflexivity.
-  * assert (distinct' (b :: l))
-      by (apply distinctCons with (a0 := a); assumption).
-    destruct n; inversion H1.
-    destruct n; inversion H6.
-    assert (length (b :: l) = S n) by intuition.
-    assert (a <= b)
-      by (apply leb_le in H0; apply Z.compare_ngt_iff in H0; omega).
-    assert (i <= a) by (apply H3; intuition).
-    apply Sorted.Sorted_LocallySorted_iff in H.
-    assert (Sorted.HdRel (fun z1 z2 : Z => is_true (leb z1 z2)) a (b :: l))
-      by (apply Sorted.HdRel_cons; assumption).
-    assert (a <> b) by
-        (unfold distinct' in H2;
-         assert (distinctIndices 0 1 (a :: b :: l)) by (split; omega);
-         apply H2 with (d := 0) in H11;
-         simpl in H11;
-         assumption).
-    apply Z.le_lteq in H8.
-    destruct H8; try contradiction.
-    assert (i + 1 <= b) by omega.
-    assert (is_true (leb (i + 1) b))
-      by (apply leb_le; apply Z.compare_ngt_iff; omega).
-    apply Sorted.HdRel_cons with (a := i + 1) (b := b) (l := l) in H13.
-    assert (forall z, In z (b :: l) -> i + 1 <= z)
-      by (apply sortedListAllGreater; assumption).
-    assert (forall z, In z (b :: l) -> i + 1 <= z < i + 1 + Z.of_nat (S n))
-      by (intros; split; try (intuition; omega);
-          assert (In z (a :: b :: l)) by intuition;
-          apply H3 in H16; rewrite ZofSucc in H16; omega).
-    assert (b :: l = zCountUp (S n) (i + 1))
-           by (apply IHLocallySorted; assumption).
-    rewrite H6.
-    assert (zCountUp (S (S n)) i = i :: zCountUp (S n) (i + 1))
-      by (assert (i + 1 = 1 + i) by omega; rewrite H17; intuition).
-    rewrite H17. rewrite <- H16.
-    assert (b = i + 1) by (inversion H16; intuition).
-    assert (a = i) by omega.
-    rewrite H19.
-    reflexivity.
-Qed.    
-    
+  induction H; simpl; intros n i ? ND Range; subst.
+  * reflexivity.
+  * rename H0 into AleL.
+    cbn [zCountUp].
+    invc ND. rename H2 into Nin. rename H3 into ND.
+
+    assert (i <= a) by (apply Range; auto).
+
+    assert (forall z, In z l -> a < z) as Alt.
+    {
+      intros z Hin.
+      apply Z.le_neq.
+      split.
+      - eapply Forall_forall; eauto.
+      - congruence.
+    }
+
+    assert (forall z : Z, In z l -> 1 + i <= z < (1 + i) + Z.of_nat (length l)) as Range'.
+    {
+      intros z Hin.
+      pose proof (Range _ (or_intror Hin)).
+      apply Alt in Hin.
+      lia.
+    }
+    specialize (IHStronglySorted (length l) (1 + i) eq_refl ltac:(auto) Range').
+    rewrite <- IHStronglySorted.
+
+    f_equal.
+    destruct l as [|b l].
+    + specialize (Range _ (or_introl eq_refl)). simpl in Range. omega.
+    + assert (b = 1 + i) by (cbn [length zCountUp] in IHStronglySorted; congruence).
+      assert (a < b) by intuition.
+      omega.
+Qed.
+
+Lemma LocallySorted_ext : forall A (R1 R2 : A -> A -> Prop),
+    (forall x y, R1 x y <-> R2 x y) ->
+    forall l, Sorted.LocallySorted R1 l -> Sorted.LocallySorted R2 l.
+Proof.
+  intros A R1 R2 HR l H.
+  induction H; constructor; firstorder.
+Qed.
+
 Lemma sortDistinctListRange : forall (l : list Z) (n : nat),
     length l = n
     -> distinct' l -> (forall z, In z l -> 0 <= z < Z.of_nat n)
     -> Sorted.LocallySorted (fun z1 z2 => is_true (leb z1 z2)) l
     -> l = zCountUp n 0.
 Proof.
-  intros. apply sortDistinctListRangeGeneral; assumption.
+  intros. apply sortDistinctListRangeGeneral; auto.
+  - apply Sorted.Sorted_StronglySorted. red. intros. omega.
+    apply Sorted.Sorted_LocallySorted_iff.
+    eapply LocallySorted_ext; [|eauto].
+    simpl. intros. rewrite leb_le. intuition.
+  - now rewrite <- distinct'_iff_NoDup.
 Qed.
-      
+
 Lemma sortedIndex : forall (p : list (Z*Z)) (n : nat),
     correct n p ->
     map zTupleToIntTuple (sort p)
@@ -1291,35 +857,31 @@ Lemma sortedIndex : forall (p : list (Z*Z)) (n : nat),
 Proof.
   intros.
   assert (Permutation p (sort p)) by (apply Permuted_sort).
-  destruct H. destruct H1.
-  apply noCollisionsIffDistinct in H2.
-  unfold allInBounds in H1. unfold inBounds in H1.
-  rewrite sndIndex with (n0 := n).
+  destruct H as (? & IB & NC).
+  apply noCollisionsIffDistinct in NC.
+  rewrite sndIndex.
   * reflexivity.
-  * rewrite map_length. rewrite <- H.
-    apply Permutation_length. apply Permutation_sym.
-    assumption.
-  * rewrite intSndToZSnd. rewrite countUpToZCountUp. rewrite zToIntMapBij.
+  * rewrite map_length.
+    erewrite <- Permutation_length by eauto.
+    rewrite intSndToZSnd. rewrite countUpToZCountUp. rewrite zToIntMapBij.
     rewrite denoteZeroOk.
-    destruct H2. destruct H3.
-    assert (Sorted.LocallySorted
-              (fun p1 p2 => is_true (leb (snd p1) (snd p2))) (sort p))
-      by apply Sorted_sort.
-    apply sortedBySecond in H5.
-    assert (Permutation (map snd p) (map snd (sort p)))
-      by (apply Permutation_map; assumption).
-    assert (distinct' (map snd (sort p)))
-      by (apply distinctPermutation with (l1 := map snd p); assumption).
-    assert (length (map snd (sort p)) = n)    
-      by (rewrite <- H; rewrite map_length; apply Permutation_length;
-          apply Permutation_sym; intuition).
-    apply sortDistinctListRange; try assumption.
-    intros. apply in_map_iff in H9. do 2 (destruct H9).
-    apply Permutation_in with (l' := p) in H10;
-      [| apply Permutation_sym; assumption].
-    apply H1 in H10.
-    destruct x. simpl in H9. rewrite <- H9. 
-    intuition.
+    apply sortDistinctListRange.
+    + rewrite map_length. auto using Permutation_length, Permutation_sym.
+    + intuition eauto using distinctPermutation, Permutation_map.
+    + intros. unfold allInBounds in *. unfold inBounds in *.
+      apply in_map_iff in H1.
+      destruct H1 as ([x y] & ? & Hin). simpl in *. subst.
+      eapply Permutation_in in Hin.
+      apply IB in Hin. intuition.
+      auto using Permutation_sym.
+    + apply sortedBySecond.
+      apply Sorted_sort.
+Qed.
+
+Lemma if_true :
+  forall A b (x y : A), b = true -> (if b then x else y) = x.
+Proof.
+  intros. subst. reflexivity.
 Qed.
 
 Lemma inRangeIfInBounds : forall (z : Z) (n : nat),
@@ -1327,61 +889,21 @@ Lemma inRangeIfInBounds : forall (z : Z) (n : nat),
 Proof.
   intros.
   unfold range.
-  rewrite denoteBindOk.
-  rewrite bigUnionIsExists.
+  space_crush.
   exists (zToInt z).
-  split.
-  * rewrite denoteFullOk. constructor.
-  * unfold lt.
-    do 2 (rewrite denoteLeOk). rewrite denoteZeroOk.
-    rewrite denoteEqualOk.
-    rewrite zToIntOk.
-    rewrite denoteNatToInt.    
-    assert ((0 <=? z) && ((z <=? Z.of_nat n)
-                            && negb (Z.eqb z (Z.of_nat n))) = true).
-    apply andb_true_iff.
-    split; [| apply andb_true_iff; split].
-    + destruct H. apply Z.leb_le. assumption.
-    + apply Z.leb_le. omega.
-    + apply negb_true_iff. apply Z.eqb_neq. omega.
-    + rewrite H0. rewrite denoteSingleOk.
-      constructor.
-Qed.
-
-Lemma lengthZeroMeansEmpty {A} : forall (l : list A),
-    length l = 0%nat -> l = [].
-Proof.
-  intros.
-  destruct l.
-  * reflexivity.
-  * inversion H.
+  split; space_crush.
+  rewrite if_true; space_crush.
 Qed.
 
 Lemma inNListSpaceIfInSpace {A} : forall (l : list A) (s : Space A) (n : nat),
     length l = n ->
     (forall a, In a l -> Ensembles.In ⟦ s ⟧ a) -> Ensembles.In ⟦ nListSpace s n ⟧ l.
 Proof.
-  intro l. induction l; intros.
-  * simpl in H. rewrite <- H.
-    unfold nListSpace. rewrite denoteSingleOk.
-    simpl. constructor.
-  * simpl in H.
-    destruct n; inversion H.
-    unfold nListSpace.
-    rewrite denoteBindOk.
-    rewrite bigUnionIsExists.
-    assert (forall a0 : A, In a0 l -> Ensembles.In ⟦ s ⟧ a0)
-      by (intros; apply H0; simpl; right; assumption).
-    exists l.
-    split.
-    + apply IHl; intuition.
-    + rewrite denoteBindOk.
-      rewrite bigUnionIsExists.
-      exists a.
-      split.
-      - apply H0. intuition.
-      - rewrite denoteSingleOk.
-        constructor.
+  induction l; intros; subst; simpl in *; space_crush.
+  exists l.
+  split; space_crush.
+  exists a.
+  space_crush.
 Qed.
 
 Lemma correctArrangementsInIndex : forall (p : list (Z*Z)) (n : nat),
@@ -1394,59 +916,41 @@ Lemma correctArrangementsInIndex : forall (p : list (Z*Z)) (n : nat),
                           (map zTupleToIntTuple p')).
 Proof.
   intros.
-  exists (ZZSort.sort p).
+  exists (sort p).
   assert (Permutation p (sort p)) by apply Permuted_sort.
-  split; try assumption.
-  rewrite denoteBindOk.
-  rewrite bigUnionIsExists.
-  assert (correct n (sort p))
-    by (apply permutationCorrect' with (l1 := p); assumption).
+  split; [assumption|].
+  space_crush.
+  assert (correct n (sort p)) by eauto using permutationCorrect'.
   exists (map fst (map zTupleToIntTuple (sort p))).
   split.
-  * unfold correct in H1.
-    destruct H1.
-    destruct H2.
-    unfold allInBounds in H2. unfold inBounds in H2.
-    apply inNListSpaceIfInSpace; try (do 2 (rewrite map_length); assumption).
-    intros.
-    apply in_map_iff in H4.
-    do 2 (destruct H4).
-    apply in_map_iff in H5.
-    do 2 (destruct H5).
-    destruct x. destruct x0.
-    simpl in H5.
-    rewrite <- H4.
-    inversion H5; subst.
+  * destruct H1 as (L & A & NC).
+    apply inNListSpaceIfInSpace; [now rewrite !map_length|].
+    intros a.
+    rewrite in_map_iff.
+    intros [[x1 y1]]. simpl. intros (?). subst a.
+    rewrite in_map_iff.
+    intros [[x2 y2]]. simpl. intros (E). inversion E; subst; clear E.
+    intro Hin.
+
     apply inRangeIfInBounds.
-    apply H2 in H6. destruct H6.
+    apply A in Hin.
+    destruct Hin.
     assumption.
-  * assert (index (map fst (map zTupleToIntTuple (sort p))) =
-            map zTupleToIntTuple (sort p))
-      by (symmetry; apply sortedIndex with (n := n); assumption).
-    rewrite H2.
-    assert (isLegal (map zTupleToIntTuple (sort p)) = true)
-      by (apply isLegalIffNoCollisions;
-          rewrite intToZInvolutiveMap;
-          unfold correct in H1;
-          destruct H1; destruct H3;
-          assumption).
-    rewrite H3.
-    rewrite denoteSingleOk.
-    constructor.
+  * erewrite <- sortedIndex by eauto.
+    rewrite (proj2 (isLegalIffNoCollisions _))
+      by (rewrite intToZInvolutiveMap; unfold correct in *; intuition).
+    space_crush.
 Qed.
-  
+
 Theorem solveNQueensComplete : forall (n : nat),
     solveNQueens n = uninhabited -> ~exists l, correct n l.
 Proof.
   intros.
   intro H'.
-  destruct H'.
-  apply correctArrangementsInIndex in H0.
-  do 2 (destruct H0).
-  unfold solveNQueens in H.
-  apply searchUninhabited in H.
-  simpl in *.
-  rewrite H in H1.
+  destruct H' as [l C].
+  apply correctArrangementsInIndex in C.
+  destruct C as (l' & P & H1).
+  rewrite searchUninhabited in H1 by auto.
   inversion H1.
 Qed.
 
@@ -1468,7 +972,7 @@ Definition solveNQueensDep n : option (solver (correct n)).
   - (* unknown, this should never happen, because we only deal with
     integers in finite ranges *)
     refine None.
-Defined.    
+Defined.
 
 End Queens.
 

--- a/src/coq/BasicTactics.v
+++ b/src/coq/BasicTactics.v
@@ -1,0 +1,40 @@
+Require Import ZArith Bool.
+
+Local Open Scope Z.
+
+(*** Convenience Tactics ***)
+
+(* Excerpted from StructTact, see: https://github.com/uwplse/StructTact/ *)
+
+Ltac inv H := inversion H; subst.
+Ltac invc H := inversion H; subst; clear H.
+
+(* Find something of the form `if foo then ... else ...` and destruct foo. *)
+Ltac break_if :=
+  match goal with
+  | [ H : context [if ?X then _ else _] |- _ ] => destruct X eqn:?
+  | [ |- context [if ?X then _ else _] ] => destruct X eqn:?
+  end.
+
+(* Find something of the form `match foo with ... end` and destruct foo. *)
+Ltac break_match :=
+  match goal with
+  | [ H : context [match ?X with _ => _ end] |- _ ] => destruct X eqn:?
+  | [ |- context [match ?X with _ => _ end] ] => destruct X eqn:?
+  end.
+
+(* Convert various boolean things to Propositional things, eg && becomes /\, etc. *)
+Ltac do_bool :=
+  repeat
+    match goal with
+    | [ H : _ && _ = true |- _ ] => apply andb_true_iff in H; destruct H
+    | [ H : _ || _ = false |- _ ] => apply orb_false_iff in H; destruct H
+    | [ H : negb _ = true |- _ ] => apply negb_true_iff in H
+    | [ H : context [(_ <=? _) = true] |- _ ] => rewrite Z.leb_le in H
+    | [ H : context [(_ <? _) = true] |- _ ] => rewrite Z.ltb_lt in H
+    | [ |- context [_ && _ = true] ] => rewrite andb_true_iff
+    | [ |- context [_ || _ = false] ] => rewrite orb_false_iff
+    | [ |- context [negb _ = true] ] => rewrite negb_true_iff
+    | [ |- context [(_ <=? _) = true] ] => rewrite Z.leb_le
+    | [ |- context [(_ <? _) = true] ] => rewrite Z.ltb_lt
+    end.

--- a/src/coq/ListEx.v
+++ b/src/coq/ListEx.v
@@ -1,4 +1,4 @@
-Require Import List.
+Require Import List BasicTactics EqDec.
 Import ListNotations.
 
 Export List.
@@ -6,18 +6,10 @@ Export ListNotations.
 
 Notation "f <$> l" := (map f l) (at level 35).
 
-Fixpoint concat {A} (l : list (list A)) : list A :=
-  match l with
-  | [] => []
-  | h::t => h ++ concat t
-  end.
-
 Lemma concatIn {A} {a:A} l {L} : In a l -> In l L -> In a (concat L).
-  intros.
-  induction L as [|l' L'].
+  induction L as [|l' L']; simpl; intros.
   + contradiction.
-  + simpl.
-    apply in_or_app.
+  + apply in_or_app.
     simpl in *.
     intuition.
     subst.
@@ -25,11 +17,71 @@ Lemma concatIn {A} {a:A} l {L} : In a l -> In l L -> In a (concat L).
 Qed.
 
 Lemma concat_app {A} {l l':list (list A)} : concat (l ++ l') = concat l ++ concat l'.
-  induction l.
-  - simpl. reflexivity.
-  - simpl in *.
-    rewrite IHl.
-    rewrite app_assoc.
-    reflexivity.
+  induction l; simpl.
+  - reflexivity.
+  - rewrite <- app_assoc.
+    congruence.
 Defined.
 
+Definition elem {A} `{eqDec A} (a:A) : list A -> bool :=
+  existsb (fun a' => if a =? a' then true else false).
+
+Lemma elem_In :
+  forall A `{eqDec A} a l,
+    elem a l = true <-> In a l.
+Proof.
+  unfold elem.
+  intros A H a l.
+  rewrite existsb_exists.
+  split.
+  - intros (x & Hin & ?).
+    break_if; congruence.
+  - intros Hin. exists a.
+    break_if; [auto | congruence].
+Qed.
+
+Fixpoint distinct {A} `{eqDec A} (l:list A) : bool :=
+  match l with
+  | a :: l => andb (negb (elem a l)) (distinct l)
+  | [] => true
+  end.
+
+Lemma distinct_sound :
+  forall A `{eqDec A} (l:list A),
+    distinct l = true -> NoDup l.
+Proof.
+  induction l; simpl; intros.
+  - constructor.
+  - do_bool.
+    constructor; auto.
+    rewrite <- elem_In with (H := H).
+    congruence.
+Qed.
+
+Lemma distinct_complete :
+  forall A `{eqDec A} (l:list A),
+    NoDup l -> distinct l = true.
+Proof.
+  induction 1; simpl.
+  - auto.
+  - do_bool.
+    split; auto.
+    rewrite <- elem_In with (H := H) in H0.
+    destruct (elem x l); simpl; congruence.
+Qed.
+
+Lemma distinct_iff_NoDup :
+  forall A `{eqDec A} (l:list A),
+    distinct l = true <-> NoDup l.
+Proof.
+  intuition eauto using distinct_sound, distinct_complete.
+Qed.
+
+Lemma map_inj : forall A B (f : A -> B),
+    (forall x y, f x = f y -> x = y) ->
+    forall l1 l2, map f l1 = map f l2 -> l1 = l2.
+Proof.
+  induction l1; destruct l2; simpl; intros; auto; try discriminate.
+  invc H0.
+  f_equal; auto.
+Qed.

--- a/src/coq/Space/Integer.v
+++ b/src/coq/Space/Integer.v
@@ -75,6 +75,23 @@ Section Definitions.
   Definition lt (n m:Int) : bool := 
     andb (le n m) (negb (equal n m)).
 
+  Lemma denoteLtOk n m : lt n m = (⟦ n ⟧ <? ⟦ m ⟧).
+  Proof.
+    unfold lt.
+    rewrite denoteLeOk.
+    apply Bool.eq_true_iff_eq.
+    rewrite Bool.andb_true_iff, Bool.negb_true_iff.
+    rewrite denoteEqualOk.
+    rewrite Z.leb_le, Z.eqb_neq, Z.ltb_lt.
+    omega.
+  Qed.
+
+  Lemma fromZInv : forall (i : Int), fromZ ⟦ i ⟧ = i.
+    intros.
+    apply denoteInjective.
+    now rewrite denoteFromZOk.
+  Qed.
+
   (* { v | n <= v < m } *)
   Definition range (n m:Int) : Space Int.
     refine (bind full (fun v : Int => _)).

--- a/src/coq/Space/Tactics.v
+++ b/src/coq/Space/Tactics.v
@@ -1,0 +1,61 @@
+Require Import Basic Integer Full.
+
+(* Include all the basic tactics as well. *)
+Require Export BasicTactics.
+
+(*** Tactics for SpaceSearch ***)
+
+(* Add all the denotation lemmas to a rewrite database. As SpaceSearch expands,
+   any new denotation lemmas should be added to the database. *)
+Hint Rewrite @denoteEmptyOk @denoteSingleOk @denoteBindOk @bigUnionIsExists : space.
+Hint Rewrite @denoteFullOk : space.
+Hint Rewrite @denoteZeroOk @denoteOneOk @denotePlusOk @denoteLeOk @denoteEqualOk : space.
+Hint Rewrite @denoteLtOk @denoteFromZOk @denoteMinusOk @fromZInv : space.
+
+Hint Constructors Singleton : space.
+
+(* The constructor for Singleton is hidden behind an invocation of Ensembles.In,
+   which makes [auto] reluctant to use it. The following lemma is better for
+   auto. *)
+Lemma In_singleton' : forall A (x : A), Singleton A x x.
+Proof. exact In_singleton. Qed.
+Hint Resolve In_singleton' : space.
+
+(* See comment above. *)
+Lemma Full_intro' : forall A (x : A), Full_set A x.
+Proof. exact Full_intro. Qed.
+Hint Resolve Full_intro' : space.
+
+(* Break apart common artifacts from rewriting by denotation lemmas. For
+   example, rewriting by bigUnionIsExists results in an existential, which we'd
+   like to destruct.
+
+   One annoying perennial issue with this tactics library is the distinction
+   between Ensembles.In and the lack thereof. The issue is that some places use
+   In, while others directly apply the Ensemble to the member. This is fine,
+   except that automation gets confused and doesn't know that they are the same.
+   Probably Ensembles.In should have been declared a notation in the first
+   place, instead of a definition, but that will never change now. It would be
+   nice to eventually come up with a better workaround than just always
+   duplicating cases, like below.  *)
+Ltac break_space :=
+  repeat
+    match goal with
+    | [ H : Ensembles.In (fun _ => exists _, _ /\ _) _ |- _ ] => destruct H as (? & ? & ?)
+    | [ H : Ensembles.In (fun _ => Singleton _ _ _) _ |- _ ] => inversion H; clear H; subst
+    | [ H : Ensembles.In (fun _ => Empty_set _ _) _ |- _ ] => inversion H
+    | [ H : exists _, _ /\ _ |- _ ] => destruct H as (? & ? & ?)
+    | [ H : Singleton _ _ _ |- _ ] => inversion H; clear H; subst
+    | [ H : Empty_set _ _ |- _ ] => inversion H
+    end.
+
+(* The main SpaceSearch workhorse tactic. Repeatedly rewrite by denotation
+   lemmas, destruct their results, and convert booleans to Props. Finally,
+   cleanup by trying a few basic Ensemble constructors. *)
+Ltac space_crush :=
+  intros;
+  repeat
+    (autorewrite with list space in *;
+     break_space;
+     do_bool);
+  auto with space.


### PR DESCRIPTION
After Steven's great talk last night, I decided to familiarize myself with SpaceSearch by working through the n-queens example and doing some small cleanup tasks. This rapidly ballooned into a bigger project than I intended, but I do think the end result is a net positive :)

A few general comments on what I did
- The most exciting change is that I introduced some new tactic automation for SpaceSearch, specifically the `space_crush` tactic (see [`src/coq/Space/Tactics.v`](https://github.com/wilcoxjay/SpaceSearch/blob/e9449f344918eb96d1c205ae26cdde1dbefc142e/src/coq/Space/Tactics.v)), which automates some of the more repetitive steps in reasoning about the denotation function.
- I moved some generic list code from `Queens.v` into `ListEx.v`.
- Other than that, the changes were localized to `Queens.v`:
    - I used the `lia` to shorten a couple long arithmetic proofs.
    - I refactored the local `fix` in `index` into a top-level `Fixpoint` called `index'`, which saved a lot of copy-pasting.
    - I proved an equivalence between the `distinct'` predicate and `NoDup` from the stdlib. This simplified some proofs because the stdlib has several facts about `NoDup` already.
    - I generally tried to clean up the nastier uses of hypothesis names, either by using automation or explicit naming.

Like I said, this turned out to be a bigger diff than I originally intended. Hopefully you all will find it useful, but feel free to rejigger things or not merge parts however you see fit. Let me know if you have any questions or suggestions!